### PR TITLE
feat: add research organization search card to dashboard

### DIFF
--- a/.changeset/research-organization-search.md
+++ b/.changeset/research-organization-search.md
@@ -1,0 +1,12 @@
+---
+"talent-finder": minor
+---
+
+feat: add research organization search card to dashboard
+
+- Add OpenAlex API integration for searching research institutions
+- Create `ResearchOrganizationSearch` component with autocomplete search
+- Display institution details (name, location, works count, citations)
+- Allow users to select and manage a pool of organizations
+- Add `/api/v1/institutions/search` endpoint
+- Include loading, empty, and error states for smooth UX

--- a/src/lib/server/openalex/errors.ts
+++ b/src/lib/server/openalex/errors.ts
@@ -1,0 +1,22 @@
+import { ApplicationError } from '$lib/server/http';
+
+/**
+ * Error thrown when OpenAlex API request fails.
+ */
+export class OpenAlexApiError extends ApplicationError {
+	constructor(message = 'OpenAlex API error', opts?: { cause?: string; details?: unknown }) {
+		super('openalex_api_error', 502, message, opts);
+	}
+}
+
+/**
+ * Error thrown when OpenAlex response cannot be parsed.
+ */
+export class OpenAlexParseError extends ApplicationError {
+	constructor(
+		message = 'Failed to parse OpenAlex response',
+		opts?: { cause?: string; details?: unknown }
+	) {
+		super('openalex_parse_error', 502, message, opts);
+	}
+}

--- a/src/lib/server/openalex/index.ts
+++ b/src/lib/server/openalex/index.ts
@@ -1,0 +1,16 @@
+export {
+	type TOpenAlexInstitution,
+	type TOpenAlexAutocompleteMeta,
+	type TOpenAlexAutocompleteResponse,
+	type TInstitution,
+	type TInstitutionSearchResponse,
+	OpenAlexInstitution,
+	OpenAlexAutocompleteMeta,
+	OpenAlexAutocompleteResponse,
+	Institution,
+	InstitutionSearchResponse
+} from './types';
+
+export { searchInstitutions } from './service';
+
+export { OpenAlexApiError, OpenAlexParseError } from './errors';

--- a/src/lib/server/openalex/openalex.test.ts
+++ b/src/lib/server/openalex/openalex.test.ts
@@ -1,0 +1,268 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { searchInstitutions } from './service';
+import { OpenAlexApiError, OpenAlexParseError } from './errors';
+import { OpenAlexInstitution, Institution, InstitutionSearchResponse } from './types';
+
+describe('openalex service', () => {
+	beforeEach(() => {
+		global.fetch = vi.fn();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	describe('searchInstitutions', () => {
+		it('should return empty results for empty query', async () => {
+			const result = await searchInstitutions('');
+
+			expect(result.institutions).toEqual([]);
+			expect(result.meta.count).toBe(0);
+			expect(global.fetch).not.toHaveBeenCalled();
+		});
+
+		it('should return empty results for whitespace-only query', async () => {
+			const result = await searchInstitutions('   ');
+
+			expect(result.institutions).toEqual([]);
+			expect(result.meta.count).toBe(0);
+			expect(global.fetch).not.toHaveBeenCalled();
+		});
+
+		it('should search and return institutions', async () => {
+			const mockResponse = {
+				meta: {
+					count: 2,
+					db_response_time_ms: 150,
+					page: 1,
+					per_page: 10
+				},
+				results: [
+					{
+						id: 'https://openalex.org/I1234',
+						display_name: 'University of Test',
+						hint: 'Test City, USA',
+						cited_by_count: 1000000,
+						works_count: 50000,
+						entity_type: 'institution' as const,
+						external_id: 'https://ror.org/test'
+					},
+					{
+						id: 'https://openalex.org/I5678',
+						display_name: 'Test Institute',
+						hint: null,
+						cited_by_count: 500000,
+						works_count: 25000,
+						entity_type: 'institution' as const,
+						external_id: null
+					}
+				]
+			};
+
+			vi.mocked(global.fetch).mockResolvedValue({
+				ok: true,
+				json: () => Promise.resolve(mockResponse)
+			} as Response);
+
+			const result = await searchInstitutions('test');
+
+			expect(global.fetch).toHaveBeenCalledWith(
+				expect.stringContaining('https://api.openalex.org/autocomplete/institutions?q=test'),
+				expect.objectContaining({
+					headers: expect.objectContaining({
+						Accept: 'application/json'
+					})
+				})
+			);
+			expect(result.institutions).toHaveLength(2);
+			expect(result.institutions[0]).toEqual({
+				id: 'https://openalex.org/I1234',
+				displayName: 'University of Test',
+				location: 'Test City, USA',
+				citedByCount: 1000000,
+				worksCount: 50000
+			});
+			expect(result.institutions[1]).toEqual({
+				id: 'https://openalex.org/I5678',
+				displayName: 'Test Institute',
+				location: null,
+				citedByCount: 500000,
+				worksCount: 25000
+			});
+			expect(result.meta.count).toBe(2);
+			expect(result.meta.responseTimeMs).toBe(150);
+		});
+
+		it('should URL encode the search query', async () => {
+			vi.mocked(global.fetch).mockResolvedValue({
+				ok: true,
+				json: () =>
+					Promise.resolve({
+						meta: { count: 0, db_response_time_ms: 50, page: 1, per_page: 10 },
+						results: []
+					})
+			} as Response);
+
+			await searchInstitutions('MIT & Harvard');
+
+			// URLSearchParams encodes spaces as + and & as %26
+			expect(global.fetch).toHaveBeenCalledWith(
+				expect.stringContaining('q=MIT+%26+Harvard'),
+				expect.any(Object)
+			);
+		});
+
+		it('should throw OpenAlexApiError on non-OK response', async () => {
+			vi.mocked(global.fetch).mockResolvedValue({
+				ok: false,
+				status: 500,
+				statusText: 'Internal Server Error'
+			} as Response);
+
+			await expect(searchInstitutions('test')).rejects.toThrow(OpenAlexApiError);
+		});
+
+		it('should throw OpenAlexApiError on network error', async () => {
+			vi.mocked(global.fetch).mockRejectedValue(new Error('Network error'));
+
+			await expect(searchInstitutions('test')).rejects.toThrow(OpenAlexApiError);
+		});
+
+		it('should throw OpenAlexParseError on invalid response format', async () => {
+			vi.mocked(global.fetch).mockResolvedValue({
+				ok: true,
+				json: () => Promise.resolve({ invalid: 'response' })
+			} as Response);
+
+			await expect(searchInstitutions('test')).rejects.toThrow(OpenAlexParseError);
+		});
+	});
+});
+
+describe('openalex errors', () => {
+	describe('OpenAlexApiError', () => {
+		it('should have correct properties', () => {
+			const error = new OpenAlexApiError('Test error', { cause: 'test cause' });
+
+			expect(error.message).toBe('Test error');
+			expect(error.code).toBe('openalex_api_error');
+			expect(error.httpStatus).toBe(502);
+			expect(error.cause).toBe('test cause');
+		});
+
+		it('should use default message', () => {
+			const error = new OpenAlexApiError();
+
+			expect(error.message).toBe('OpenAlex API error');
+		});
+	});
+
+	describe('OpenAlexParseError', () => {
+		it('should have correct properties', () => {
+			const error = new OpenAlexParseError('Parse error', { cause: 'invalid JSON' });
+
+			expect(error.message).toBe('Parse error');
+			expect(error.code).toBe('openalex_parse_error');
+			expect(error.httpStatus).toBe(502);
+			expect(error.cause).toBe('invalid JSON');
+		});
+
+		it('should use default message', () => {
+			const error = new OpenAlexParseError();
+
+			expect(error.message).toBe('Failed to parse OpenAlex response');
+		});
+	});
+});
+
+describe('openalex types', () => {
+	describe('OpenAlexInstitution schema', () => {
+		it('should validate valid institution', () => {
+			const validInstitution = {
+				id: 'https://openalex.org/I123',
+				display_name: 'Test University',
+				hint: 'Test City',
+				cited_by_count: 1000,
+				works_count: 500,
+				entity_type: 'institution' as const,
+				external_id: 'https://ror.org/test'
+			};
+
+			const result = OpenAlexInstitution.safeParse(validInstitution);
+
+			expect(result.success).toBe(true);
+		});
+
+		it('should allow null hint', () => {
+			const institution = {
+				id: 'https://openalex.org/I123',
+				display_name: 'Test University',
+				hint: null,
+				cited_by_count: 1000,
+				works_count: 500,
+				entity_type: 'institution' as const,
+				external_id: null
+			};
+
+			const result = OpenAlexInstitution.safeParse(institution);
+
+			expect(result.success).toBe(true);
+		});
+
+		it('should reject invalid entity_type', () => {
+			const institution = {
+				id: 'https://openalex.org/I123',
+				display_name: 'Test University',
+				hint: null,
+				cited_by_count: 1000,
+				works_count: 500,
+				entity_type: 'author',
+				external_id: null
+			};
+
+			const result = OpenAlexInstitution.safeParse(institution);
+
+			expect(result.success).toBe(false);
+		});
+	});
+
+	describe('Institution schema', () => {
+		it('should validate simplified institution', () => {
+			const institution = {
+				id: 'https://openalex.org/I123',
+				displayName: 'Test University',
+				location: 'Test City',
+				citedByCount: 1000,
+				worksCount: 500
+			};
+
+			const result = Institution.safeParse(institution);
+
+			expect(result.success).toBe(true);
+		});
+	});
+
+	describe('InstitutionSearchResponse schema', () => {
+		it('should validate search response', () => {
+			const response = {
+				institutions: [
+					{
+						id: 'https://openalex.org/I123',
+						displayName: 'Test University',
+						location: 'Test City',
+						citedByCount: 1000,
+						worksCount: 500
+					}
+				],
+				meta: {
+					count: 1,
+					responseTimeMs: 100
+				}
+			};
+
+			const result = InstitutionSearchResponse.safeParse(response);
+
+			expect(result.success).toBe(true);
+		});
+	});
+});

--- a/src/lib/server/openalex/service.ts
+++ b/src/lib/server/openalex/service.ts
@@ -1,0 +1,98 @@
+import type {
+	TOpenAlexAutocompleteResponse,
+	TInstitution,
+	TInstitutionSearchResponse
+} from './types';
+import { OpenAlexAutocompleteResponse } from './types';
+import { OpenAlexApiError, OpenAlexParseError } from './errors';
+
+const OPENALEX_BASE_URL = 'https://api.openalex.org';
+
+/**
+ * Searches for institutions using the OpenAlex autocomplete API.
+ * @param query - The search query string
+ * @returns Search results with institutions
+ */
+export const searchInstitutions = async (query: string): Promise<TInstitutionSearchResponse> => {
+	if (!query.trim()) {
+		return {
+			institutions: [],
+			meta: { count: 0, responseTimeMs: 0 }
+		};
+	}
+
+	const url = new URL(`${OPENALEX_BASE_URL}/autocomplete/institutions`);
+	url.searchParams.set('q', query);
+
+	const response = await fetchOpenAlex(url);
+	const data = parseAutocompleteResponse(response);
+
+	return {
+		institutions: data.results.map(mapToInstitution),
+		meta: {
+			count: data.meta.count,
+			responseTimeMs: data.meta.db_response_time_ms
+		}
+	};
+};
+
+/**
+ * Fetches data from OpenAlex API.
+ * @param url - The URL to fetch
+ * @returns Raw JSON response
+ */
+const fetchOpenAlex = async (url: URL): Promise<unknown> => {
+	try {
+		const response = await fetch(url.toString(), {
+			headers: {
+				Accept: 'application/json',
+				'User-Agent': 'talent-finder (mailto:contact@talent-finder.org)'
+			}
+		});
+
+		if (!response.ok) {
+			throw new OpenAlexApiError(`OpenAlex API returned ${response.status}`, {
+				cause: `HTTP ${response.status}: ${response.statusText}`
+			});
+		}
+
+		return await response.json();
+	} catch (error) {
+		if (error instanceof OpenAlexApiError) {
+			throw error;
+		}
+		throw new OpenAlexApiError('Failed to fetch from OpenAlex API', {
+			cause: error instanceof Error ? error.message : 'Unknown error'
+		});
+	}
+};
+
+/**
+ * Parses and validates OpenAlex autocomplete response.
+ * @param data - Raw response data
+ * @returns Validated response
+ */
+const parseAutocompleteResponse = (data: unknown): TOpenAlexAutocompleteResponse => {
+	const result = OpenAlexAutocompleteResponse.safeParse(data);
+	if (!result.success) {
+		throw new OpenAlexParseError('Invalid OpenAlex response format', {
+			cause: result.error.message
+		});
+	}
+	return result.data;
+};
+
+/**
+ * Maps OpenAlex institution to simplified format.
+ * @param institution - OpenAlex institution object
+ * @returns Simplified institution
+ */
+const mapToInstitution = (
+	institution: TOpenAlexAutocompleteResponse['results'][number]
+): TInstitution => ({
+	id: institution.id,
+	displayName: institution.display_name,
+	location: institution.hint,
+	citedByCount: institution.cited_by_count,
+	worksCount: institution.works_count
+});

--- a/src/lib/server/openalex/types.ts
+++ b/src/lib/server/openalex/types.ts
@@ -1,0 +1,64 @@
+import { z } from 'zod';
+
+/**
+ * OpenAlex institution from autocomplete response.
+ */
+export const OpenAlexInstitution = z.object({
+	id: z.string(),
+	display_name: z.string(),
+	hint: z.string().nullable(),
+	cited_by_count: z.number().int().nonnegative(),
+	works_count: z.number().int().nonnegative().nullable(),
+	entity_type: z.literal('institution'),
+	external_id: z.string().nullable()
+});
+
+export type TOpenAlexInstitution = z.infer<typeof OpenAlexInstitution>;
+
+/**
+ * OpenAlex autocomplete response metadata.
+ */
+export const OpenAlexAutocompleteMeta = z.object({
+	count: z.number().int().nonnegative(),
+	db_response_time_ms: z.number().int().nonnegative(),
+	page: z.number().int().positive(),
+	per_page: z.number().int().positive()
+});
+
+export type TOpenAlexAutocompleteMeta = z.infer<typeof OpenAlexAutocompleteMeta>;
+
+/**
+ * OpenAlex autocomplete response for institutions.
+ */
+export const OpenAlexAutocompleteResponse = z.object({
+	meta: OpenAlexAutocompleteMeta,
+	results: z.array(OpenAlexInstitution)
+});
+
+export type TOpenAlexAutocompleteResponse = z.infer<typeof OpenAlexAutocompleteResponse>;
+
+/**
+ * Simplified institution for client-side use.
+ */
+export const Institution = z.object({
+	id: z.string(),
+	displayName: z.string(),
+	location: z.string().nullable(),
+	citedByCount: z.number().int().nonnegative(),
+	worksCount: z.number().int().nonnegative().nullable()
+});
+
+export type TInstitution = z.infer<typeof Institution>;
+
+/**
+ * Institution search result response.
+ */
+export const InstitutionSearchResponse = z.object({
+	institutions: z.array(Institution),
+	meta: z.object({
+		count: z.number().int().nonnegative(),
+		responseTimeMs: z.number().int().nonnegative()
+	})
+});
+
+export type TInstitutionSearchResponse = z.infer<typeof InstitutionSearchResponse>;

--- a/src/lib/ui/ResearchOrganizationSearch.svelte
+++ b/src/lib/ui/ResearchOrganizationSearch.svelte
@@ -1,0 +1,204 @@
+<script lang="ts">
+	import { Icon, LoadingSpinner, Alert } from '$lib/ui';
+	import type { TInstitution } from '$lib/server/openalex';
+
+	/** Debounce delay in milliseconds */
+	const DEBOUNCE_MS = 300;
+
+	/** Minimum query length to trigger search */
+	const MIN_QUERY_LENGTH = 2;
+
+	let searchQuery = $state('');
+	let searchResults = $state<TInstitution[]>([]);
+	let selectedOrganizations = $state<TInstitution[]>([]);
+	let isLoading = $state(false);
+	let error = $state<string | null>(null);
+	let debounceTimer = $state<ReturnType<typeof setTimeout> | null>(null);
+
+	/**
+	 * Searches for institutions using the API.
+	 * @param query - The search query string
+	 */
+	const searchInstitutions = async (query: string): Promise<void> => {
+		if (query.length < MIN_QUERY_LENGTH) {
+			searchResults = [];
+			return;
+		}
+
+		isLoading = true;
+		error = null;
+
+		try {
+			const response = await fetch(`/api/v1/institutions/search?q=${encodeURIComponent(query)}`);
+
+			if (!response.ok) {
+				throw new Error(`Search failed: ${response.status}`);
+			}
+
+			const data = await response.json();
+			searchResults = data.institutions;
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'An error occurred while searching';
+			searchResults = [];
+		} finally {
+			isLoading = false;
+		}
+	};
+
+	/**
+	 * Handles input changes with debouncing.
+	 */
+	const handleInput = (): void => {
+		if (debounceTimer) {
+			clearTimeout(debounceTimer);
+		}
+
+		debounceTimer = setTimeout(() => {
+			searchInstitutions(searchQuery);
+		}, DEBOUNCE_MS);
+	};
+
+	/**
+	 * Adds an organization to the selected pool.
+	 * @param organization - The organization to add
+	 */
+	const addOrganization = (organization: TInstitution): void => {
+		if (!selectedOrganizations.some((org) => org.id === organization.id)) {
+			selectedOrganizations = [...selectedOrganizations, organization];
+		}
+		searchQuery = '';
+		searchResults = [];
+	};
+
+	/**
+	 * Removes an organization from the selected pool.
+	 * @param organizationId - The ID of the organization to remove
+	 */
+	const removeOrganization = (organizationId: string): void => {
+		selectedOrganizations = selectedOrganizations.filter((org) => org.id !== organizationId);
+	};
+
+	/**
+	 * Formats a number for display.
+	 * @param num - The number to format
+	 */
+	const formatNumber = (num: number | null): string => {
+		if (num === null) return 'N/A';
+		return new Intl.NumberFormat().format(num);
+	};
+</script>
+
+<div class="card">
+	<h2 class="text-xl font-semibold mb-4">Research Organization Search</h2>
+
+	<!-- Search Input -->
+	<div class="relative">
+		<div class="relative">
+			<Icon
+				icon="lucide:search"
+				width="20"
+				height="20"
+				class="absolute left-3 top-1/2 -translate-y-1/2 text-secondary-400"
+			/>
+			<input
+				type="text"
+				bind:value={searchQuery}
+				oninput={handleInput}
+				placeholder="Search for research organizations..."
+				class="w-full pl-10 pr-10 py-2.5 border border-secondary-300 dark:border-secondary-600 rounded-lg bg-white dark:bg-secondary-800 text-secondary-900 dark:text-secondary-100 placeholder-secondary-400 dark:placeholder-secondary-500 focus:ring-2 focus:ring-primary-500 focus:border-transparent transition-colors"
+			/>
+			{#if isLoading}
+				<div class="absolute right-3 top-1/2 -translate-y-1/2">
+					<LoadingSpinner size="sm" />
+				</div>
+			{/if}
+		</div>
+
+		<!-- Search Results Dropdown -->
+		{#if searchResults.length > 0}
+			<div
+				class="absolute z-10 w-full mt-1 bg-white dark:bg-secondary-800 border border-secondary-200 dark:border-secondary-700 rounded-lg shadow-lg max-h-64 overflow-y-auto"
+			>
+				{#each searchResults as result (result.id)}
+					<button
+						type="button"
+						onclick={() => addOrganization(result)}
+						class="w-full px-4 py-3 text-left hover:bg-primary-50 dark:hover:bg-primary-900/20 border-b border-secondary-100 dark:border-secondary-700 last:border-b-0 transition-colors"
+					>
+						<p class="font-medium text-secondary-900 dark:text-secondary-100">
+							{result.displayName}
+						</p>
+						{#if result.location}
+							<p class="text-sm text-secondary-500 dark:text-secondary-400">
+								{result.location}
+							</p>
+						{/if}
+						<p class="text-xs text-secondary-400 dark:text-secondary-500 mt-1">
+							{formatNumber(result.worksCount)} works &middot; {formatNumber(result.citedByCount)} citations
+						</p>
+					</button>
+				{/each}
+			</div>
+		{/if}
+
+		<!-- Empty State for Search -->
+		{#if searchQuery.length >= MIN_QUERY_LENGTH && !isLoading && searchResults.length === 0 && !error}
+			<div
+				class="absolute z-10 w-full mt-1 bg-white dark:bg-secondary-800 border border-secondary-200 dark:border-secondary-700 rounded-lg shadow-lg p-4"
+			>
+				<p class="text-secondary-500 dark:text-secondary-400 text-center">
+					No organizations found for "{searchQuery}"
+				</p>
+			</div>
+		{/if}
+	</div>
+
+	<!-- Error State -->
+	{#if error}
+		<div class="mt-3">
+			<Alert variant="error">
+				{error}
+			</Alert>
+		</div>
+	{/if}
+
+	<!-- Selected Organizations Pool -->
+	<div class="mt-6">
+		<h3 class="text-sm font-medium text-secondary-700 dark:text-secondary-300 mb-3">
+			Selected Organizations ({selectedOrganizations.length})
+		</h3>
+
+		{#if selectedOrganizations.length === 0}
+			<p class="text-sm text-secondary-500 dark:text-secondary-400 italic">
+				No organizations selected. Use the search above to add organizations.
+			</p>
+		{:else}
+			<div class="space-y-2">
+				{#each selectedOrganizations as organization (organization.id)}
+					<div
+						class="flex items-center justify-between p-3 bg-secondary-50 dark:bg-secondary-700/50 rounded-lg border border-secondary-200 dark:border-secondary-600"
+					>
+						<div class="flex-1 min-w-0">
+							<p class="font-medium text-secondary-900 dark:text-secondary-100 truncate">
+								{organization.displayName}
+							</p>
+							{#if organization.location}
+								<p class="text-sm text-secondary-500 dark:text-secondary-400 truncate">
+									{organization.location}
+								</p>
+							{/if}
+						</div>
+						<button
+							type="button"
+							onclick={() => removeOrganization(organization.id)}
+							class="ml-3 p-1.5 text-secondary-400 hover:text-error-600 dark:hover:text-error-400 hover:bg-error-50 dark:hover:bg-error-900/20 rounded transition-colors"
+							aria-label="Remove {organization.displayName}"
+						>
+							<Icon icon="lucide:x" width="18" height="18" />
+						</button>
+					</div>
+				{/each}
+			</div>
+		{/if}
+	</div>
+</div>

--- a/src/lib/ui/index.ts
+++ b/src/lib/ui/index.ts
@@ -12,3 +12,4 @@ export { default as Signup } from './Signup.svelte';
 export { default as StatCard } from './StatCard.svelte';
 export { default as ThemeSection } from './ThemeSection.svelte';
 export { default as ThemeToggle } from './ThemeToggle.svelte';
+export { default as ResearchOrganizationSearch } from './ResearchOrganizationSearch.svelte';

--- a/src/routes/api/docs/openapi.json
+++ b/src/routes/api/docs/openapi.json
@@ -21,6 +21,10 @@
 			"description": "Gestion des utilisateurs"
 		},
 		{
+			"name": "institutions",
+			"description": "Recherche d'institutions de recherche via OpenAlex"
+		},
+		{
 			"name": "repository",
 			"description": "Statistiques du dépôt git"
 		},
@@ -238,6 +242,48 @@
 					},
 					"500": {
 						"description": "Erreur serveur",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiError"
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/institutions/search": {
+			"get": {
+				"operationId": "searchInstitutions",
+				"summary": "Rechercher des institutions",
+				"description": "Recherche des institutions de recherche via l'API OpenAlex (autocomplete). Retourne jusqu'à 10 résultats.",
+				"tags": ["institutions"],
+				"parameters": [
+					{
+						"name": "q",
+						"in": "query",
+						"required": true,
+						"schema": {
+							"type": "string",
+							"minLength": 1
+						},
+						"description": "Terme de recherche (nom de l'institution)"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Résultats de recherche",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/InstitutionSearchResponse"
+								}
+							}
+						}
+					},
+					"502": {
+						"description": "Erreur API OpenAlex",
 						"content": {
 							"application/json": {
 								"schema": {
@@ -478,6 +524,60 @@
 					},
 					"urls": {
 						"$ref": "#/components/schemas/GitHubUrls"
+					}
+				}
+			},
+			"Institution": {
+				"type": "object",
+				"required": ["id", "displayName", "citedByCount"],
+				"properties": {
+					"id": {
+						"type": "string",
+						"description": "OpenAlex ID de l'institution"
+					},
+					"displayName": {
+						"type": "string",
+						"description": "Nom de l'institution"
+					},
+					"location": {
+						"type": "string",
+						"nullable": true,
+						"description": "Localisation (ville, pays)"
+					},
+					"citedByCount": {
+						"type": "integer",
+						"description": "Nombre de citations"
+					},
+					"worksCount": {
+						"type": "integer",
+						"nullable": true,
+						"description": "Nombre de publications"
+					}
+				}
+			},
+			"InstitutionSearchResponse": {
+				"type": "object",
+				"required": ["institutions", "meta"],
+				"properties": {
+					"institutions": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/Institution"
+						},
+						"description": "Liste des institutions trouvées (max 10)"
+					},
+					"meta": {
+						"type": "object",
+						"properties": {
+							"count": {
+								"type": "integer",
+								"description": "Nombre de résultats"
+							},
+							"responseTimeMs": {
+								"type": "integer",
+								"description": "Temps de réponse en millisecondes"
+							}
+						}
 					}
 				}
 			}

--- a/src/routes/api/v1/institutions/search/+server.ts
+++ b/src/routes/api/v1/institutions/search/+server.ts
@@ -1,0 +1,20 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+import { searchInstitutions } from '$lib/server/openalex';
+import { mapErrorToResponse } from '$lib/server/http';
+
+/**
+ * GET /api/v1/institutions/search
+ * Searches for research institutions using the OpenAlex API.
+ * @param q - Search query string (required)
+ */
+export const GET: RequestHandler = async ({ url }) => {
+	try {
+		const query = url.searchParams.get('q') ?? '';
+		const results = await searchInstitutions(query);
+		return json(results);
+	} catch (error: unknown) {
+		return mapErrorToResponse(error);
+	}
+};

--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import { Icon } from '$lib/ui';
+	import { Icon, ResearchOrganizationSearch } from '$lib/ui';
 	import {
 		createThemeStore,
 		hasThemePreferences,
@@ -250,6 +250,9 @@
 					{/each}
 				</div>
 			</div>
+
+			<!-- Research Organization Search Card -->
+			<ResearchOrganizationSearch />
 		</div>
 
 		<!-- Coming Soon Section -->


### PR DESCRIPTION
- Add OpenAlex API integration for searching research institutions
- Create ResearchOrganizationSearch component with autocomplete search
- Display institution details (name, location, works count, citations)
- Allow users to select and manage a pool of organizations
- Add /api/v1/institutions/search endpoint with OpenAPI documentation
- Include loading, empty, and error states for smooth UX
- Add unit tests for OpenAlex service module (16 tests)
- Update documentation (CLAUDE.md files)